### PR TITLE
Feature/fix keyarchiver issues when there are no strings

### DIFF
--- a/Classes/GLLingoManager.h
+++ b/Classes/GLLingoManager.h
@@ -17,7 +17,7 @@
 -(void) fetch;
 
 -(void)setApiKey:(NSString *)apiKey andAppId:(NSString *)appId;
--(void)setApiKey:(NSString *)apiKey andAppId:(NSString *)appId andPreferedLanguage:(NSString *) languageCode;
+-(void)setApiKey:(NSString *)apiKey andAppId:(NSString *)appId andPreferedLanguage:(NSString *)languageCode;
 
 // Macro
 #define GLLocalizedString(key, default) [[GLLingoManager sharedManager] getLocalizedStringForKey:key withDefault:default]

--- a/Classes/GLLingoManager.m
+++ b/Classes/GLLingoManager.m
@@ -76,7 +76,6 @@
         if (stringDictionary.count != 0) {
             self.stringDictionary = stringDictionary;
             [self persistDictionary:stringDictionary forLanguageCode:[self languageCode]];
-            NSLog(@"New data has been fetched!");
         };
     }];
 }
@@ -128,7 +127,6 @@
                 if(error)
                 {
                     // TODO: Handle error
-                    NSLog(@"Wops.. error: %@", error.localizedDescription);
                     return;
                 }
 
@@ -149,7 +147,6 @@
                 if(error)
                 {
                     //TODO
-                    NSLog(@"Wops.. error: %@", error.localizedDescription);
                     return;
                 }
 
@@ -159,7 +156,6 @@
             }];
         }
     } else {
-        NSLog(@"No apiKey set!");
     }
 }
 
@@ -173,21 +169,24 @@
     }
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     NSData *encodedObject = [defaults objectForKey:persistedDictionaryLanguageKey];
-    NSDictionary *dictionary = [NSKeyedUnarchiver unarchiveObjectWithData:encodedObject];
+    NSDictionary *dictionary = [[NSDictionary alloc] init];
+    if (encodedObject) {
+        dictionary = [NSKeyedUnarchiver unarchiveObjectWithData:encodedObject];
+    }
     return dictionary;
 }
 
 -(void)persistDictionary:(NSDictionary *)dictionary forLanguageCode:(NSString *) langCode
 {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSString *persistedDictionaryLanguageKey = [NSString stringWithFormat:@"%@_%@", PERSISTED_DICTIONARY_KEY, langCode];
+
+
     if (dictionary.count == 0)
     {
-        //[defaults removeObjectForKey:persistedDictionaryLanguageKey]; // Why?
+        [defaults removeObjectForKey:persistedDictionaryLanguageKey];
         return;
     }
-
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-
-    NSString *persistedDictionaryLanguageKey = [NSString stringWithFormat:@"%@_%@", PERSISTED_DICTIONARY_KEY, langCode];
 
 
     NSData *encodedObject = [NSKeyedArchiver archivedDataWithRootObject:dictionary];
@@ -200,7 +199,6 @@
     NSString *language = [[NSLocale preferredLanguages] firstObject];
     NSArray *stringParts = [language componentsSeparatedByString:@"-"];
     NSString *languageCode = [stringParts firstObject];
-    //NSString *region = stringParts.count > 1 ? [stringParts lastObject] : @""; // Remove?
     return languageCode;
 }
 

--- a/Classes/GLNetworkService.m
+++ b/Classes/GLNetworkService.m
@@ -32,7 +32,6 @@ NSString *timestampLastFetchKey = @"GL_LAST_FETCH_KEY";
     }
 
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@/%@/translations?%@%@&from_date=%li", getLingoApiTranslationsUrl, appId, @"language_code=", langCode, (long)timestampInSeconds]];
-    NSLog(@"Get Lingo url: %@", url);
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
 
     [request setHTTPMethod:@"GET"];
@@ -55,7 +54,6 @@ NSString *timestampLastFetchKey = @"GL_LAST_FETCH_KEY";
         }
 
         NSError *jsonError;
-//        NSArray *arrayOfStringObjects  = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:&jsonError];
         NSDictionary *jsonData  = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:&jsonError];
 
 
@@ -79,7 +77,6 @@ NSString *timestampLastFetchKey = @"GL_LAST_FETCH_KEY";
 
         // Save timestamp
         [prefs setObject:[NSDate date] forKey:timestampLastFetchKey];
-        NSLog(@"Saved timestamp %@", [NSDate date]);
 
         // Check meta
         NSNumber *status = jsonData[@"meta"][@"status"];
@@ -99,7 +96,6 @@ NSString *timestampLastFetchKey = @"GL_LAST_FETCH_KEY";
             NSMutableDictionary *dicOfStringObjects = [[NSMutableDictionary alloc] init];
             for(NSDictionary *dic in arrayOfDictionaries){
                 GLStringObject *newString = [[GLStringObject alloc] initWithDictionary:dic];
-                NSLog(@"Value: %@ forKey: %@", newString.value, newString.key);
                 [dicOfStringObjects setValue:newString forKey:newString.key];
             }
             NSDictionary *returnDictionary = [[NSDictionary alloc] initWithDictionary:dicOfStringObjects];

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GetLingo Manager
 
-GetLingo Manager is a library to help developer connect to GetLingo Services to handle your apps translations.
+GetLingo Manager is a library to help developer connect to Getlingo Services to handle your apps translations.
 
 ## Demo app
 
@@ -29,10 +29,22 @@ First, add `GLLingoManager` to your AppDelegate.m
 #import <GLLingoManager.h>
 ```
 
-Then you need to instantiate the singelton and set api key and app id. You can also set an optional initial prefered language code if you want to force the app to use a specific language. So in `didFinishLaunchingWithOptions:` add the following line:
+Then you need to instantiate the singelton and set api key and app id. So in `didFinishLaunchingWithOptions:` add the following line:
+
+```objc
+[[GLLingoManager sharedManager] setApiKey:@"YOUR-API-KEY" andAppId:@"YOUR-APP-ID"];
+```
+
+You can also set an optional initial prefered language code if you want to force the app to use a specific language:
 
 ```objc
 [[GLLingoManager sharedManager] setApiKey:@"YOUR-API-KEY" andAppId:@"YOUR-APP-ID" andPreferedLanguage:@"en"];
+```
+
+To use Getlingo for your strings you have to use our macro, `GLLocalizedString`. `GLLocalizedString` takes two parameters, `GLLocalizedString(key, default)`, the `key` is used to match translations that have been fetched from the getlingo.io API to your app's strings. The `default` value is used if no matching translations are found. To set the text of a label you simply do this:
+
+```objc
+self.myLabel.text = GLLocalizedString(@"sign_in", @"Sign in");
 ```
 
 ## Changelog
@@ -43,4 +55,3 @@ Then you need to instantiate the singelton and set api key and app id. You can a
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details
-


### PR DESCRIPTION
- Fixed one issue that occurred with `NSKeyedUnarchiver` when there are no translations. 
- Removed `NSLogs`, NSLogs (slightly) affect performance. Think it is better to use breakpoints and later [NSAssertionHandler](http://nshipster.com/nsassertionhandler/) to handle exceptions and debugging.
- Remove unused lines of code. 
- Updated the readme with information about the macro and the method `(void)setApiKey:(NSString *)apiKey andAppId:(NSString *)appId;`
